### PR TITLE
Fix code scanning alert no. 119: Uncontrolled command line

### DIFF
--- a/extensions/itranslate/src/common/itranslate.shared.tsx
+++ b/extensions/itranslate/src/common/itranslate.shared.tsx
@@ -16,7 +16,7 @@ import querystring from "node:querystring";
 import { LanguageConflict, OCRServiceProviderMiss, ServiceProviderMiss } from "../components/TranslateError";
 import translate from "@vitalets/google-translate-api";
 import Core from "@alicloud/pop-core";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
@@ -900,8 +900,8 @@ export function clearAllHistory() {
 
 export function say(text: string, voice?: string) {
   try {
-    const command = `say -v "${voice}" "${text.replace(/"/g, " ")}"`;
-    execSync(command);
+    const args = ['-v', voice, text.replace(/"/g, " ")];
+    execFileSync('say', args);
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
Fixes [https://github.com/Centaurioun/raycast-extensions/security/code-scanning/119](https://github.com/Centaurioun/raycast-extensions/security/code-scanning/119)

To fix the problem, we should avoid using `execSync` with a concatenated string that includes user-provided input. Instead, we can use `execFileSync` which allows us to pass command arguments as an array of strings, thus avoiding the risk of command injection.

- Replace the `execSync` call with `execFileSync`.
- Ensure that the `voice` and `text` parameters are passed as separate arguments to the `say` command.
- Update the import statement to include `execFileSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
